### PR TITLE
Add the option to hide recommendations

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -37,7 +37,7 @@ home = ["HTML", "RSS", "Algolia"]
   sidebar_about_description = "Software Developer, Open Source Enthusiast and Life Adventurer"
   sidebar_avatar = "img/avatar-zhaohuabing.jpg"      # use absolute URL, seeing it's used in both `/` and `/about/`
 
-  featured_tags = true 
+  featured_tags = true
   featured_condition_size = 2 
 
   # Baidu Analytics
@@ -64,10 +64,14 @@ home = ["HTML", "RSS", "Algolia"]
   wechat         = "link of wechat QR code image"
   #pinterest     = "full profile url in pinterest"
   #medium        = "full profile url in medium"
-  
+
+  friends = true
+
   [[params.friend_link]]
   title = "Linda的博客"
   href =  "https://zhaozhihan.com"
+
+  bookmarks = true
 
   [[params.bookmark_link]]
   title =  "Martin Fowler"

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -80,29 +80,35 @@
                 sidebar-container">
 
                 <!-- Featured Tags -->
+                {{ if .Site.Params.featured_tags }}
                 <section>
                     <hr class="hidden-sm hidden-xs">
                     <h5><a href="/tags/">FEATURED TAGS</a></h5>
                     <div class="tags">
-                    {{ $featured_condition_size := .Site.Params.featured_condition_size }} 
-                    {{ range $name, $taxonomy := .Site.Taxonomies.tags }}
-                       {{ if gt (len $taxonomy.Pages) $featured_condition_size }} 
-                            <a href="{{ "/tags/" | relLangURL }}{{ $name | urlize }}" title="{{ $name }}">
-                                {{ $name }}
-                            </a>
-                       {{ end }} 
-                    {{ end }}
+                        {{ $featured_condition_size := .Site.Params.featured_condition_size }}
+                        {{ range $name, $taxonomy := .Site.Taxonomies.tags }}
+                        {{ if gt (len $taxonomy.Pages) $featured_condition_size }}
+                        <a href="{{ "/tags/" | relLangURL }}{{ $name | urlize }}" title="{{ $name }}">
+                        {{ $name }}
+                        </a>
+                        {{ end }}
+                        {{ end }}
                     </div>
                 </section>
+                {{ end }}
 
                 <!-- Friends Blog -->
-                <hr>
-                <h5>FRIENDS</h5>
-                <ul class="list-inline">
-                    {{ range .Site.Params.friend_link }}
+                {{ if .Site.Params.friends }}
+                <section>
+                    <hr>
+                    <h5>FRIENDS</h5>
+                    <ul class="list-inline">
+                        {{ range .Site.Params.friend_link }}
                         <li><a target="_blank" href="{{.href}}">{{.title}}</a></li>
-                    {{ end }}
-                </ul>
+                        {{ end }}
+                    </ul>
+                </section>
+                {{ end }}
             </div>
         </div>
     </div>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -130,21 +130,29 @@
                 </ul>
             </div>
     </section>
-   <!-- Friends Blog -->
-   <hr>
-   <h5>FRIENDS</h5>
-   <ul class="list-inline">
-       {{ range .Site.Params.friend_link }}
-           <li><a target="_blank" href="{{.href}}">{{.title}}</a></li>
-       {{ end }}
-   </ul>
-   
+    <!-- Friends Blog -->
+    {{ if .Site.Params.friends }}
+    <section>
+        <hr class="hidden-sm hidden-xs">
+        <h5>FRIENDS</h5>
+        <ul class="list-inline">
+            {{ range .Site.Params.friend_link }}
+            <li><a target="_blank" href="{{.href}}">{{.title}}</a></li>
+            {{ end }}
+        </ul>
+    </section>
+    {{ end }}
+
     <!-- Bookmarks -->
-   <hr>
-   <h5>BOOKMARKS</h5>
-   <ul class="list-inline">
-   {{ range .Site.Params.bookmark_link }}
-           <li><a target="_blank" href="{{.href}}">{{.title}}</a></li>
-       {{ end }}
-   </ul>
+    {{ if .Site.Params.bookmarks }}
+    <section>
+        <hr>
+        <h5>BOOKMARKS</h5>
+        <ul class="list-inline">
+            {{ range .Site.Params.bookmark_link }}
+            <li><a target="_blank" href="{{.href}}">{{.title}}</a></li>
+            {{ end }}
+        </ul>
+    </section>
+    {{ end }}
 </div>


### PR DESCRIPTION
Specifically, allow users to hide 'Friends' and 'Bookmarks' lists.

Update default template to reflect config.toml settings.

> Note: I'm less sure if updating the default is something you'd like to see happen or not, but I think it makes the overall page look cleaner.

### before
_Empty headings in footer and sidebar_
<img width="867" alt="screen shot 2018-11-25 at 3 19 12 pm" src="https://user-images.githubusercontent.com/18273771/48980168-fd147500-f0c5-11e8-8c78-4649f7ef55d4.png">
<img width="329" alt="screen shot 2018-11-25 at 3 19 03 pm" src="https://user-images.githubusercontent.com/18273771/48980169-fd147500-f0c5-11e8-8a32-765d1e23bc04.png">

### after
_No headings where no content (this screenshot might not do the change justice, but it basically means that your website doesn't look actively incomplete if you don't have content in these sections)_
<img width="330" alt="screen shot 2018-11-25 at 3 16 04 pm" src="https://user-images.githubusercontent.com/18273771/48980171-07cf0a00-f0c6-11e8-9838-06b4bf9a5753.png">
<img width="1165" alt="screen shot 2018-11-25 at 3 15 56 pm" src="https://user-images.githubusercontent.com/18273771/48980173-07cf0a00-f0c6-11e8-9517-d17df12cd92d.png">
