### PR TITLE
Add syntax highlight feature with highlight.js

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -44,4 +44,9 @@
     
     <!-- Custom Theme JavaScript -->
     <script src="{{ "js/hux-blog.min.js" | relURL }}"></script>
+	
+    <!-- Use the docco color scheme of highlight.js to highlight the code in the page -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.13.1/styles/docco.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.13.1/highlight.min.js"></script>
+    <script>hljs.initHighlightingOnLoad();</script>
 </head>


### PR DESCRIPTION
Use the docco color scheme of highlight.js to highlight the code in the page.