### PR TITLE
add ogp params

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -5,11 +5,46 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="google-site-verification" content="xBT4GhYoi5qRD5tr338pgPM5OWHHIDR6mNg1a3euekI" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <!-- start ogp -->
+    <meta property="og:site_name" content="{{ .Site.Title }}">
+    <meta property="og:type" content="article">
+
+    {{ if .Params.thumbnail }}
+    <meta property="og:image" content="{{ .Site.BaseURL }}{{ .Params.thumbnail }}">
+    <meta property="twitter:image" content="{{ .Site.BaseURL }}{{ .Params.thumbnail }}" />
+    {{ else }}
+    <meta property="og:image" content="{{ .Site.BaseURL }}/{{ .Site.Params.header_image }}">
+    <meta property="twitter:image" content="{{ .Site.BaseURL }}/{{ .Site.Params.header_image }}" />
+    {{ end }}
+
+    {{ if .Params.title }}
+    <meta name="title" content="{{ .Params.title }}" />
+    <meta property="og:title" content="{{ .Params.title }}" />
+    <meta property="twitter:title" content="{{ .Params.title }}" />
+    {{ else }}
+    <meta name="title" content="{{ .Site.Params.title }}" />
+    <meta property="og:title" content="{{ .Site.Params.title }}" />
+    <meta property="twitter:title" content="{{ .Site.Params.title }}" />
+    {{ end }}
+
     {{ if .Params.description }}
     <meta name="description" content="{{ .Params.description }}">
+    <meta property="og:description" content="{{ .Params.description }}" />
+    <meta property="twitter:description" content="{{ .Params.description }}" />
     {{ else }}
     <meta name="description" content="{{ .Site.Params.description }}">
+    <meta property="og:description" content="{{ .Site.Params.description }}" />
+    <meta property="twitter:description" content="{{ .Site.Params.description }}" />
     {{ end }}
+
+    {{ if .Params.summary }}
+    <meta property="twitter:card" content="{{ .Params.summary }}" />
+    {{ else }}
+    <meta property="twitter:card" content="summary" />
+    {{ end }}
+    <!-- end ogp -->
+
     <meta name="keyword"  content="{{ .Site.Params.keyword }}">
     <link rel="shortcut icon" href="{{ "img/favicon.ico" | relURL }}">
 


### PR DESCRIPTION
@zhaohuabing 
I tried this issue #32 

I will report the verification results
Best regards

1,OGP thumbnail setting
![ogp-setting-default](https://user-images.githubusercontent.com/35297716/51985366-044e6980-24e1-11e9-8ef6-b646ed2b6eab.png)

2,OGP no setting
I made it possible to apply header_image when OGP is not set
![ogp-no-setting](https://user-images.githubusercontent.com/35297716/51985365-044e6980-24e1-11e9-9fc9-4dfbc5384ffa.png)

3,OGP thumbnail setting and param setting  summary_large_image
post params
```---
title: OGP Image Large
description: 説明文
date: 2019-01-29T13:50:39.455Z
summary: summary_large_image
categories:
  - SAMPLE
tags:
  - SAMPLE
thumbnail: /img/uploads/tu-tu-322210-unsplash.jpg
```

![ogp-setting-large](https://user-images.githubusercontent.com/35297716/51985367-044e6980-24e1-11e9-8803-3d59ab28e108.png)