### PR TITLE
Fix for relative links in friends and bookmarks

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -137,7 +137,7 @@
         <h5>FRIENDS</h5>
         <ul class="list-inline">
             {{ range .Site.Params.friend_link }}
-            <li><a target="_blank" href="{{.href}}">{{.title}}</a></li>
+            <li><a target="_blank" href="{{.href | relLangURL}}">{{.title}}</a></li>
             {{ end }}
         </ul>
     </section>
@@ -150,7 +150,7 @@
         <h5>BOOKMARKS</h5>
         <ul class="list-inline">
             {{ range .Site.Params.bookmark_link }}
-            <li><a target="_blank" href="{{.href}}">{{.title}}</a></li>
+            <li><a target="_blank" href="{{.href | relLangURL}}">{{.title}}</a></li>
             {{ end }}
         </ul>
     </section>


### PR DESCRIPTION
Fix for issue #35 

If your website baseurl is something like:

https://somedomain.com/somedirectory/

Then you create a relative bookmark or friend link in your site it resolves to the root directory (https://somedomain.com/) instead of the correct path (https://somedomain.com/somedirectory/)

This can be fixed by updating the links to reflect the baseurl, but it can be resolved code.