### PR TITLE
allow to override the default behaviour for showtoc

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -51,8 +51,7 @@
                 col-md-10 col-md-offset-1
                 post-container">
 
-                {{ if eq .Params.showtoc false }}
-                {{ else }}
+                {{ if not (eq (.Param "showtoc") false) }}
                 <header>
                     <h2>TOC</h2>
                 </header>


### PR DESCRIPTION
 .. with sitewide param in config.toml

since showtoc is by default true you how to add 'showtoc: false' to all your blog posts
if you dont want the toc beeing added.

keep the same behaviour as before but with the addition that you can now add a showtoc
as a sitewide param in config.toml to change the default behaviour (fallback value).

|Site Variable | Page Variable |  show toc? |
| ------------ | ------------- | ----------- | 
|    null      |    null       |    yes     |
|    null      |    false      |    no      |
|    null      |    true       |    yes     |
|    false     |    null       |    no      |
|    false     |    false      |    no      |
|    false     |    true       |    yes     |
|    true      |    null       |    true    |
|    true      |    false      |    no      |
|    true      |    true       |    yes     |