### PR TITLE
Add missing email icon in about_me section at sidebar.html

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -50,7 +50,7 @@
                    </a>
                </li>
                {{ end }}
-			   {{ with .Site.Params.social.email }}
+	       {{ with .Site.Params.social.email }}
                <li>
                    <a href="mailto:{{ . }}">
                        <span class="fa-stack fa-lg">

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -50,6 +50,16 @@
                    </a>
                </li>
                {{ end }}
+			   {{ with .Site.Params.social.email }}
+               <li>
+                   <a href="mailto:{{ . }}">
+                       <span class="fa-stack fa-lg">
+                           <i class="fa fa-circle fa-stack-2x"></i>
+                           <i class="fa fa-envelope fa-stack-1x fa-inverse"></i>
+                       </span>
+                   </a>
+               </li>
+               {{ end }}
                {{ with .Site.Params.social.twitter }}
                <li>
                    <a href="{{ . }}">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20196556/66722902-f6d8d580-ee0a-11e9-8bce-718953c75f0f.png)

The email link is a frequently used entry for a personal website. It would be nice to add it to the about_me section (in case it was accidentally omitted).