### PR TITLE
add site param 'omit_categories'

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -21,6 +21,7 @@ home = ["HTML", "RSS", "Algolia"]
 
   image_404 = "img/404-bg.jpg"
   title_404 = "你来到了没有知识的荒原 :("
+  omit_categories = false
 
   # leancloud storage for page view counter
   page_view_conter = false 

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -24,10 +24,12 @@
                     <li>
                         <a href="{{ "/" | relLangURL }}">Home</a>
                     </li>
-                    {{ range $name, $taxonomy := .Site.Taxonomies.categories }}
-                    <li>
-                        <a href="{{ "categories/" | relLangURL }}{{ $name | urlize }}">{{ $name }}</a>
-                    </li>
+                    {{ if not .Site.Params.omit_categories }}
+                        {{ range $name, $taxonomy := .Site.Taxonomies.categories }}
+                        <li>
+                            <a href="{{ "categories/" | relLangURL }}{{ $name | urlize }}">{{ $name }}</a>
+                        </li>
+                        {{ end }}
                     {{ end }}
                     
 		    {{ range .Site.Params.addtional_menus }}


### PR DESCRIPTION
I would rather not have all of the categories show up in my top bar. This adds a site param which omits the categories from showing up. Preserves default behaviour.