### PR TITLE
feat: implement posts archiving page

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -103,6 +103,9 @@ home = ["HTML", "RSS", "Algolia"]
   title =  "BOOKS"
   href =  "/top/books/"
   [[params.addtional_menus]]
+  title =  "ARCHIVE"
+  href =  "/top/archive/"
+  [[params.addtional_menus]]
   title =  "ABOUT"
   href =  "/top/about/"
 

--- a/exampleSite/content/top/archive.md
+++ b/exampleSite/content/top/archive.md
@@ -1,0 +1,6 @@
+---
+title: "Posts Archive"
+layout: archive
+type: post
+description: Archive of historical posts.
+---

--- a/layouts/_default/archive.html
+++ b/layouts/_default/archive.html
@@ -1,0 +1,45 @@
+{{ define "main" }}
+{{ $pages := (where (where .Site.Pages "Type" "post") "IsPage" true) }}
+
+<div class="container">
+    <div class="row">
+   	    <div class="
+            col-lg-8 col-lg-offset-1
+            col-md-8 col-md-offset-1
+            col-sm-12
+            col-xs-12
+            post-container
+        ">
+            <div class="archive-list">
+                {{ range ($pages.GroupByDate "2006") }}
+                {{ if gt .Key 1 }}
+                    {{ $.Scratch.Set "count" 1 }}
+                    {{ range .Pages  }}
+                        {{ if (eq ($.Scratch.Get "count") 1) }}
+                            {{ $.Scratch.Set "count" 0 }}
+                            <h1 class="title is-4 has-text-weight-normal">{{ .Date.Format "2006" }}</h1>
+                        {{ end }}
+                    {{ end }}
+
+                    <ul>
+                    {{ range .Pages }}
+                        <li>
+                            <span>{{ .Date.Format "01/02" }}</span> — 
+                            <a href="{{ .RelPermalink }}">
+                                {{ .Title }}
+                            </a>
+                        </li>
+                    {{ end }}
+                    </ul>
+
+                {{ end }}
+                {{ end }}
+            </div>
+       	</div>
+        {{ partial "sidebar.html" . }}
+	</div>
+</div>
+
+
+<hr />
+{{ end }}


### PR DESCRIPTION
Add a layout for the posts archiving page and enable the page in `exampleSite`.

Here is the preview when running the `exampleSite`:

![image](https://user-images.githubusercontent.com/24987826/130115831-05bc0294-5c85-44f0-8036-fd92c3ef7142.png)

