### PR TITLE
fix: wrong class name for wechat fontawesome icon

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -73,7 +73,7 @@
                         <a target="_blank" href="{{ . | relURL }}">
                             <span class="fa-stack fa-lg">
                                 <i class="fas fa-circle fa-stack-2x"></i>
-                                <i class="fab fa-wechat fa-stack-1x fa-inverse"></i>
+                                <i class="fab fa-weixin fa-stack-1x fa-inverse"></i>
                             </span>
                         </a>
                     </li>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -95,7 +95,7 @@
                    <a target="_blank" href="{{ . | relURL}}">
                        <span class="fa-stack fa-lg">
                            <i class="fas fa-circle fa-stack-2x"></i>
-                           <i class="fab fa-wechat fa-stack-1x fa-inverse"></i>
+                           <i class="fab fa-weixin fa-stack-1x fa-inverse"></i>
                        </span>
                    </a>
                </li>


### PR DESCRIPTION
The wechat icon cannot be displayed after applying #95 due to the wrong class name in Font Awesome v5 is used. Change it from `fab fa-wechat` to `fab fa-weixin` (see the [reference](https://fontawesome.com/v5.15/icons/weixin?style=brands)).