### PR TITLE
Feature: Added nice little boxes for hints, warnings and tips

### DIFF
--- a/layouts/shortcodes/notice.html
+++ b/layouts/shortcodes/notice.html
@@ -1,0 +1,60 @@
+{{ $_hugo_config := `{ "version": 1 }` }}
+<style media="screen">
+    /* notice block */
+    div.notices {
+        margin: 2rem 0;
+        position: relative;
+    }
+    div.notices p {
+        padding: 15px;
+        display: block;
+        /*font-size: 1rem;*/
+        margin-top: 0rem;
+        margin-bottom: 0rem;
+        color: #666;
+    }
+    div.notices p:first-child:before {
+        position: absolute;
+        top: 2px;
+        color: #fff;
+        font-family: "Font Awesome 5 Free";
+        font-weight: 900;
+        content: "\f06a";
+        left: 10px;
+    }
+    div.notices p:first-child:after {
+        position: absolute;
+        top: 2px;
+        color: #fff;
+        left: 3rem;
+    }
+    div.notices.info p {
+        border-top: 30px solid #F0B37E;
+        background: #FFF2DB;
+    }
+    div.notices.info p:first-child:after {
+        content: 'Info';
+    }
+    div.notices.warning p {
+        border-top: 30px solid rgba(217, 83, 79, 0.8);
+        background: #FAE2E2;
+    }
+    div.notices.warning p:first-child:after {
+        content: 'Warning';
+    }
+    div.notices.note p {
+        border-top: 30px solid #6AB0DE;
+        background: #E7F2FA;
+    }
+    div.notices.note p:first-child:after {
+        content: 'Note';
+    }
+    div.notices.tip p {
+        border-top: 30px solid rgba(92, 184, 92, 0.8);
+        background: #E6F9E6;
+    }
+    div.notices.tip p:first-child:after {
+        content: 'Tip';
+    }
+</style>
+<div class="notices {{ .Get 0 }}" {{ if len .Params | eq 2 }} id="{{ .Get 1 }}" {{ end }}>{{ .Inner }}</div>

--- a/layouts/shortcodes/notice.html
+++ b/layouts/shortcodes/notice.html
@@ -7,6 +7,7 @@
     }
     div.notices p {
         padding: 15px;
+        white-space: pre-wrap;
         display: block;
         /*font-size: 1rem;*/
         margin-top: 0rem;


### PR DESCRIPTION
use code like this:

```
{{% notice tip %}}
Don't forget to make a first backup manually (just in case) an setup a periodical backup job on the long term 😉
{{% /notice %}}
```
to build such boxes:
![image](https://user-images.githubusercontent.com/56593749/150975651-d876c9af-ad2f-4975-88f3-a823ed377266.png)

The boxes feature layouts for the keywords `tip` (green), `info` (orange), `note` (blue) and `warning` (red)