### PR TITLE
Update post_list.html to make the "Posted by" subtext more consistent

### DIFF
--- a/layouts/partials/post_list.html
+++ b/layouts/partials/post_list.html
@@ -28,7 +28,7 @@
             {{ end }}
         {{ end }}
     {{ else }}
-        Posted by{{ with .Params.author }}{{ . }}{{ else }}{{ .Site.Title }}{{ end }}  {{ .Date.Format "Monday, January 2, 2006" }}
+        Posted by {{ with .Params.author }}{{ . }}{{ else }}{{ .Site.Title }}{{ end }}  {{ .Date.Format "Monday, January 2, 2006" }}
         <!-- Don't show "Last Modified on" if update happened on the same day. -->
         {{ if (and (not .Lastmod.IsZero) (not (eq (dateFormat "2006-01-02" .Lastmod) (dateFormat "2006-01-02" .Date)))) }}
             <br>Last Modified on {{ dateFormat "Monday, January 2, 2006" .Params.LastMod }} 

--- a/layouts/partials/post_list.html
+++ b/layouts/partials/post_list.html
@@ -28,7 +28,7 @@
             {{ end }}
         {{ end }}
     {{ else }}
-        Posted by {{ with .Params.author }}{{ . }}{{ else }}{{ .Site.Title }}{{ end }}  {{ .Date.Format "Monday, January 2, 2006" }}
+        Posted by {{ with .Params.author }}{{ . }}{{ else }}{{ .Site.Title }}{{ end }} on {{ .Date.Format "Monday, January 2, 2006" }}
         <!-- Don't show "Last Modified on" if update happened on the same day. -->
         {{ if (and (not .Lastmod.IsZero) (not (eq (dateFormat "2006-01-02" .Lastmod) (dateFormat "2006-01-02" .Date)))) }}
             <br>Last Modified on {{ dateFormat "Monday, January 2, 2006" .Params.LastMod }} 


### PR DESCRIPTION
The `post_list.html` is missing a whitespace between the "Posted by" and the author's name. Moreover, it's also missing an "on" keyword between the author's name and the post's date.

This whitespace and the "on" keyword are however present in the `single.html` page.
https://github.com/zhaohuabing/hugo-theme-cleanwhite/blob/7b64a06446db7aa1620e99186302a5ebe3f976cf/layouts/_default/single.html#L36
https://github.com/zhaohuabing/hugo-theme-cleanwhite/blob/7b64a06446db7aa1620e99186302a5ebe3f976cf/layouts/_default/single.html#L42

I'm proposing this change to make the layout consistent.

Thanks!