### PR TITLE
Add if statement for pager section

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -83,6 +83,7 @@
                 {{ partial "reward.html" . }}
                 {{ end }}
 
+                {{ if or (.PrevInSection) (.NextInSection) }}
                 <hr>
                 <ul class="pager">
                     {{ if .PrevInSection }}
@@ -98,6 +99,8 @@
                     </li>
                     {{ end }}
                 </ul>
+                {{ end }}
+
                 {{ partial "comments.html" . }}
             </div>
 


### PR DESCRIPTION
Hi, I'm new to hugo theme, and I just published my first post with cleanwhite.

I noticed that the horizontal line and the block are still there even though the previous/next buttons do not need to be displayed, which is a bit odd to me.

![截圖 2022-07-07 上午7 32 21](https://user-images.githubusercontent.com/55390098/177661419-6700b51f-cf97-4b60-87f5-d18893f4c970.png)

Therefore, I added an if statement for the pager section, rendered as follows:

![截圖 2022-07-07 上午7 37 36](https://user-images.githubusercontent.com/55390098/177661606-f51bff16-3a43-4961-a9cd-5b313dcd7b2e.png)

Just some edge cases, if it's ok for others then I'll close the PR. And thanks again for the nice theme!

