### PR TITLE
Pages should be built with search only key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Add the following variables to your hugo site config so the search page can get 
 algolia_search = true
 algolia_appId = {{ YOUR_APP_ID }}
 algolia_indexName = {{ YOUR_INDEX_NAME }}
-algolia_apiKey = {{ YOUR_ADMIN_KEY }}
+algolia_apiKey = {{ YOUR_SEARCH_ONLY_KEY }}
 ```
 Open search page in your browser: http://localhost:1313/search
 

--- a/exampleSite/content/post/readme.md
+++ b/exampleSite/content/post/readme.md
@@ -125,7 +125,7 @@ Add the following variables to your hugo site config so the search page can get 
 algolia_search = true
 algolia_appId = {{ YOUR_APP_ID }}
 algolia_indexName = {{ YOUR_INDEX_NAME }}
-algolia_apiKey = {{ YOUR_ADMIN_KEY }}
+algolia_apiKey = {{ YOUR_SEARCH_ONLY_KEY }}
 ```
 Open search page in your browser: http://localhost:1313/search
 


### PR DESCRIPTION
The API key given in the `config.toml` is visible to visitors of `/search/`.  As such it should not be the admin key as indicated but the search-only key.  According to Algolia:

> `Search-Only API Key`:
> This is the public API key to use in your frontend code. This key is only usable for search queries and sending data to the Insights API.

> `Admin API Key`
> This is the ADMIN API key. Please keep it secret and use it ONLY from your backend: this key is used to create, update and DELETE your indices. You can also use it to manage your API keys