### PR TITLE
fix about link on avatar

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -10,10 +10,10 @@
     <!-- Short About -->
 	{{ if .Site.Params.about_me }}
     <section class="visible-md visible-lg">
-	<!--<hr><h5><a href="{{ "/top/about" | relLangURL }}">ABOUT ME</a></h5>-->
+	<!--<hr><h5><a href="{{ "/about" | relLangURL }}">ABOUT ME</a></h5>-->
         <div class="short-about">
             {{ with .Site.Params.sidebar_avatar }}
-            <a href="{{ "/top/about" | relLangURL }}">
+            <a href="{{ "/about" | relLangURL }}">
                <img src="{{ . | relURL }}" alt="avatar" style="cursor: pointer" />
             </a>
             {{ end }}


### PR DESCRIPTION
Hello, thank you very much for the awesome Hugo theme!

I noticed the about link on the avatar is broken even for example site then I try to fix that. I am not sure that is the correct way to fix the issue. I would be grateful if you could advise me.

## Before
- If I click the avatar photo on the top page, it jumps to `top/about` and shows 404.
<img width="750" alt="Screen Shot 2022-09-23 at 13 47 52" src="https://user-images.githubusercontent.com/45537257/191893992-092df6b2-9f75-4e5a-8b37-b2fe2de33bd9.png">

<img width="750" alt="Screen Shot 2022-09-23 at 13 28 48" src="https://user-images.githubusercontent.com/45537257/191892528-10f2eb2e-95f6-43fa-a399-b27a66b70972.png">


## After
By fixing this line to `<a href="{{ "/about" | relLangURL }}">`(remove the `/top` path), this link works for me.
https://github.com/zhaohuabing/hugo-theme-cleanwhite/blob/ac188d67d1e82445b593142f6d20be4db19e26ed/layouts/partials/sidebar.html#L16

<img width="750" alt="Screen Shot 2022-09-23 at 13 29 34" src="https://user-images.githubusercontent.com/45537257/191892535-7808ed44-a0c7-454d-9d50-671b4ca0011b.png">


