### PR TITLE
feat: add conditional for attribution to upstream repo

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -18,6 +18,7 @@ home = ["HTML", "RSS", "Algolia"]
   description = "赵化冰，程序员, 开源爱好者，生活探险家 | 这里是 赵化冰 的博客，与你一起发现更大的世界。"
   keyword = "赵化冰, zhaohuabing, Zhaohuabing, , 赵化冰的网络日志, 赵化冰的博客, Zhaohuabing Blog, 博客, 个人网站, 互联网, Web, 云原生, PaaS, Istio, Kubernetes, 微服务, Microservice"
   slogan = "路在脚下，心向远方"
+  upstreamAttribution = true
 
   image_404 = "img/404-bg.jpg"
   title_404 = "你来到了没有知识的荒原 :("

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -209,6 +209,7 @@
              </ul>
 		<p class="copyright text-muted">
                     Copyright &copy; {{ .Site.Title }} {{ now.Year }} {{- if .Site.Params.icp }} | {{ with .Site.Params.icp }}{{ . | markdownify }}{{ end }}{{- end}}
+                    {{ if .Site.Params.upstreamAttribution }}
                     <br>
                     <a href="https://themes.gohugo.io/hugo-theme-cleanwhite">CleanWhite Hugo Theme</a> by <a href="https://zhaohuabing.com">Huabing</a> |
                     <iframe
@@ -216,6 +217,7 @@
                         frameborder="0" scrolling="0" width="100px" height="20px"
                         src="https://ghbtns.com/github-btn.html?user=zhaohuabing&repo=hugo-theme-cleanwhite&type=star&count=true" >
                     </iframe>
+                    {{ end }}
                 </p>
             </div>
         </div>


### PR DESCRIPTION
This commit adds a conditional flag for the attribution to @zhaohuabing in the footer partial.

This change is similar to #156 by @pengbin2015, but makes the behavior optional while keeping the default behavior as retaining the attribution and iframe to add the GitHub star.

Since this is a backwards-compatible feature add, I'd suggest this be versioned `2.1.0` per the [semantic versioning guidelines](https://semver.org/).

Thanks!