### PR TITLE
Fixed bugs caused by removing a feature in the new version

### DIFF
--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -19,7 +19,7 @@
 <script src="{{ "js/iDisqus.js" | relURL }}"></script>
 <script>
 var disq = new iDisqus('disqus-comment', {
-    forum: '{{ .Site.DisqusShortname}}',
+    forum: '{{ .Site.Config.Services.Disqus.Shortname }}',
     api: '{{ .Site.Params.disqus_proxy }}',
 	site: '{{ .Site.Params.disqus_site }}',
     mode: 1,
@@ -28,7 +28,7 @@ var disq = new iDisqus('disqus-comment', {
     emojiPreview: true
 });
 </script>
-{{ else if .Site.DisqusShortname }}
+{{ else if .Site.Config.Services.Disqus.Shortname }}
 <!-- disqus 评论框 end -->
 <div id="disqus-comment"></div>
 {{ template "_internal/disqus.html" . }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -92,7 +92,7 @@
 
 </head>
 
-{{ if .Site.GoogleAnalytics }}
+{{ if .Site.Config.Services.GoogleAnalytics.ID }}
 {{ template "_internal/google_analytics.html" . }}
 {{ end }}
 


### PR DESCRIPTION
Fixed bugs caused by removing a feature in the new version:

ERROR deprecated: .Site.GoogleAnalytics was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.135.0. Use .Site.Config.Services.GoogleAnalytics.ID instead.

---

ERROR deprecated: .Site.DisqusShortname  was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.135.0. Use .Site.Config.Services.Disqus.Shortname instead.