### PR TITLE
add 'title' attribute for catalog title

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -336,7 +336,7 @@
             n = $(this).prop('tagName').toLowerCase();
             i = "#" + $(this).prop('id');
             t = $(this).text();
-            c = $('<a href="' + i + '" rel="nofollow">' + t + '</a>');
+            c = $('<a href="' + i + '" rel="nofollow" title="' + t + '">' + t + '</a>');
             l = $('<li class="' + n + '_nav"></li>').append(c);
             $(selector).append(l);
         });


### PR DESCRIPTION
When the title is too long, the table of contents cannot fully display the title. By adding the 'title' attribute, the full title can be displayed when the mouse is placed on the table of contents.

The effect is shown in the figure below:
![image](https://github.com/user-attachments/assets/ac450f41-f64f-4692-9b14-ebd6b1b9851e)
