### PR TITLE
enable HTML rendering for sidebar

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -18,7 +18,7 @@
             </a>
             {{ end }}
             {{ with .Site.Params.sidebar_about_description }}
-                <p>{{ . }}</p>
+                <p>{{ . | safeHTML }}</p>
             {{ end }}
            <!-- SNS Link -->
            <ul class="list-inline">


### PR DESCRIPTION
enable HTML rendering (e.g., `<br>` tags) for `sidebar_about_description`