### PR TITLE
Add support for server side rendering of mathematical formulae

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $ cd themes
 $ git clone https://github.com/zhaohuabing/hugo-theme-cleanwhite.git
 $ cp -r hugo-theme-cleanwhite/exampleSite/** ../
 $ cd ..
-$ hugo serve
+$ hugo server
 ```
 
 If your site is already a git project, you may want to choose to add the cleanwhite theme as a submodule to avoid messing up your existing git repository.
@@ -58,7 +58,7 @@ $ git submodule add https://github.com/zhaohuabing/hugo-theme-cleanwhite.git the
 Run  Hugo Build-in Server Locally
 
 ```
-$ hugo serve -t  hugo-theme-cleanwhite
+$ hugo server -t  hugo-theme-cleanwhite
 ```
 Now enter [`localhost:1313`](http://localhost:1313) in the address bar of your browser.
 

--- a/exampleSite/content/post/2025-07-06-mathematical-formulae.md
+++ b/exampleSite/content/post/2025-07-06-mathematical-formulae.md
@@ -1,0 +1,201 @@
+---
+layout:     post
+title:      "Authoring mathematical formulae"
+description: "Cleanwhite theme now has built-in support for authoring mathematical or chemical equations"
+excerpt: "The theme uses Hugo's embedded instance of the KaTeX display engine to render mathematical markup to HTML at build time."
+date:    2025-07-06
+author: "Andreas Deininger"
+image: "/img/2018-05-23-service_2_service_auth/background.jpg"
+publishDate: 2025-07-06
+tags:
+    - Math
+    - KaTeX 
+URL: "/2025/07/06/mathematical-formulae/"
+categories: [ tips ]    
+---
+
+## Authoring mathematical and chemical equations
+
+
+Cleanwhite theme now has built-in \(\KaTeX\) support, so that you can easily include
+complex mathematical formulae into your web page, either inline or centred
+on its own line. The theme uses Hugo's embedded instance of the KaTeX 
+display engine to render mathematical markup to HTML at build time.
+With this server side rendering of formulae, the same output is produced,
+regardless of your browser or your environment.  
+
+[\(\LaTeX\)](https://www.latex-project.org/) is a high-quality typesetting
+system for the production of technical and scientific documentation. Due to its
+excellent math typesetting capabilities, \(\TeX\) became the de facto standard
+for the communication and publication of scientific documents, especially if
+these documents contain a lot of mathematical formulae. Designed and mostly
+written by Donald Knuth, the initial version was released in 1978. Dating back
+that far, \(\LaTeX\) has `pdf` as its primary output target and is not
+particularly well suited for producing HTML output for the Web. Fortunately,
+with [\(\KaTeX\)](https://katex.org/) there exists a fast and easy-to-use
+JavaScript library for \(\TeX\) math rendering on the web, which is embedded
+into Hugo as of Hugo version v0.132.0.
+
+As already mentioned above, mathematical or chemical equations can be shown either inline or in display mode:
+
+### Inline formulae
+
+The following code sample produces a text line with three inline formulae:
+
+```tex
+When \(a \ne 0\), there are two solutions to \(ax^2 + bx + c= 0\) and they are \(x = {-b \pm \sqrt{b^2-4ac} \over 2a}\).
+```
+
+When \(a \ne 0\), there are two solutions to \(ax^2 + bx + c= 0\) and they are
+\(x = {-b \pm \sqrt{b^2-4ac} \over 2a}\).
+
+### Formulae in display mode
+
+The following code sample produces an introductory text line followed by a
+formula numbered as `(1)` residing on its own line:
+
+````markdown
+The probability of getting \(k\) heads when flipping \(n\) coins is:
+\[
+\tag*{(1)} P(E) = {n \choose k} p^k (1-p)^{n-k}
+\]
+````
+
+As an alternative to the standard syntax used above, formulae can also be
+authored using a [GLFM math block](https://docs.gitlab.com/ee/user/markdown.html#math):
+
+````markdown
+The probability of getting \(k\) heads when flipping \(n\) coins is:
+
+```math
+\tag*{(1)} P(E) = {n \choose k} p^k (1-p)^{n-k}
+```
+````
+
+Both standard syntax and `math` block render to the same formula:
+
+The probability of getting \(k\) heads when flipping \(n\) coins is:
+
+```math
+\tag*{(1)}  P(E) = {n \choose k} p^k (1-p)^{n-k}
+```
+
+This [wiki page](https://en.wikibooks.org/wiki/LaTeX/Mathematics) provides in-depth
+information about typesetting mathematical formulae using the \(\LaTeX\)
+typesetting system.
+
+### Activating KaTeX support
+
+#### Enable `passthrough` extension
+
+All you have to do is to enable and configure the goldmark `passthrough` extension
+inside your `hugo.toml`/`hugo.yaml`/`hugo.json`. You may want to edit the definition of the delimiters to
+meet your own needs. For details, see the official
+[Hugo docs](https://gohugo.io/content-management/mathematics/#step-1).
+
+```toml
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.extensions]
+      [markup.goldmark.extensions.passthrough]
+        enable = true
+        [markup.goldmark.extensions.passthrough.delimiters]
+          block = [['\[', '\]'], ['$$', '$$']]
+          inline = [['\(', '\)']]
+```
+
+Internally, cleanwhite theme creates and uses Hugo's `render-passthrough`
+[hook](https://gohugo.io/render-hooks/passthrough/) when generating math
+equations at build-time. This hook is part of the theme, no need for any user action.
+
+#### Media types for download of KaTeX fonts
+
+Just for your information, no need for any action from you as user:
+KaTeX brings its own font files for rendering mathematical formulae.
+In order to enable the download of these font files locally during build time, two
+additional [media types](https://gohugo.io/configuration/media-types/#create-a-media-type)
+had to be created by adding the lines below to the `hugo.toml` configuration file of the cleanwhite theme:
+
+```toml
+mediaTypes:
+  font/woff:
+    suffixes:
+    - woff
+  font/woff2:
+    suffixes:
+    - woff2
+```
+
+
+With the `passthrough` extension enabled and the media types defined, support
+of \(\KaTeX\) is automatically enabled when you author a `math` code block on
+your page or when you add a mathematical formula to your page using one of the
+passthrough delimiter pairs defined above.
+
+### Display of Chemical Equations and Physical Units
+
+[mhchem](https://www.ctan.org/pkg/mhchem) is a \(\LaTeX\) package for
+typesetting chemical molecular formulae and equations. Fortunately, \(\KaTeX\)
+provides the `mhchem`
+[extension](https://github.com/KaTeX/KaTeX/tree/main/contrib/mhchem) that makes
+the `mhchem` package accessible when authoring content for the web. As of hugo
+version v0.144.0, the `mhchem` extension is enabled in Hugo's embedded KaTeX
+instance by default, therefore you can easily include chemical equations into
+your page. An equation can be shown either inline or can reside on its own line.
+The following code sample produces a text line including an inline chemical
+equation:
+
+```mhchem
+*Precipitation of barium sulfate:* \(\ce{SO4^2- + Ba^2+ -> BaSO4 v}\)
+```
+
+_Precipitation of barium sulfate:_ \(\ce{SO4^2- + Ba^2+ -> BaSO4 v}\)
+
+More complex equations can be displayed on their own line using the block
+delimiters defined:
+
+<!-- prettier-ignore-start -->
+````markdown
+\[
+\tag*{(2)} \ce{Zn^2+  <=>[+ 2OH-][+ 2H+]  $\underset{\text{amphoteric hydroxide}}{\ce{Zn(OH)2 v}}$  <=>[+ 2OH-][+ 2H+]  $\underset{\text{tetrahydroxozincate}}{\ce{[Zn(OH)4]^2-}}$}
+\]
+````
+<!-- prettier-ignore-end -->
+
+Alternatively, you can use a code block adorned with `chem` in order to render
+the equation:
+
+````markdown
+```chem
+\tag*{(2)} \ce{Zn^2+  <=>[+ 2OH-][+ 2H+]  $\underset{\text{amphoteric hydroxide}}{\ce{Zn(OH)2 v}}$  <=>[+ 2OH-][+ 2H+]  $\underset{\text{tetrahydroxozincate}}{\ce{[Zn(OH)4]^2-}}$}
+```
+````
+
+Both standard syntax and `chem` block renders to the same equation:
+
+<!-- prettier-ignore-start -->
+\[
+\tag*{(2)} \ce{Zn^2+  <=>[+ 2OH-][+ 2H+]  $\underset{\text{amphoteric hydroxide}}{\ce{Zn(OH)2 v}}$  <=>[+ 2OH-][+ 2H+]  $\underset{\text{tetrahydroxozincate}}{\ce{[Zn(OH)4]^2-}}$}
+\]
+<!-- prettier-ignore-end -->
+
+The [manual](https://mhchem.github.io/MathJax-mhchem/) for mchem’s input syntax
+provides in-depth information about typesetting chemical formulae and physical
+units using the `mhchem` tool.
+
+Use of `mhchem` is not limited to the authoring of chemical equations. By using
+the included `\pu` command, pretty looking physical units can be written with
+ease, too. The following code sample produces two text lines with four numbers
+plus their corresponding physical units:
+
+```mhchem
+* Scientific number notation: \(\pu{1.2e3 kJ}\) or \(\pu{1.2E3 kJ}\) \\
+* Divisions: \(\pu{123 kJ/mol}\) or \(\pu{123 kJ//mol}\)
+```
+
+- Scientific number notation: \(\pu{1.2e3 kJ}\) or \(\pu{1.2E3 kJ}\)
+- Divisions: \(\pu{123 kJ/mol}\) or \(\pu{123 kJ//mol}\)
+
+For a complete list of options when authoring physical units, have a look at the
+[section](https://mhchem.github.io/MathJax-mhchem/#pu) on physical units in the
+`mhchem` documentation.

--- a/exampleSite/content/post/readme.md
+++ b/exampleSite/content/post/readme.md
@@ -161,6 +161,24 @@ reward = true
 ```
 * Replace the QR codes of Wechat Pay & Alipay by overriding the photos in folder /static/img/reward/, otherwise the money will be sent to my accounts!
 
+### Authoring mathematical and chemical equations with \(\KaTeX\)
+
+If you want to make use if KaTeX on your site, enable and configure the goldmark `passthrough` extension
+inside your `hugo.toml`/`hugo.yaml`/`hugo.json`. You may want to edit the definition of the delimiters to
+meet your own needs. For details, see the official [Hugo docs](https://gohugo.io/content-management/mathematics/#step-1).
+
+```toml
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.extensions]
+      [markup.goldmark.extensions.passthrough]
+        enable = true
+        [markup.goldmark.extensions.passthrough.delimiters]
+          block = [['\[', '\]'], ['$$', '$$']]
+          inline = [['\(', '\)']]
+```
+
+Afterwards, you can author mathematical and chemical equations on your site. Please read this [blog post] for more details on this subject.
 
 ## Thank
 Thanks for the great jobs of [huxblog Jekyll Theme](https://github.com/Huxpro/huxpro.github.io) and [Clean Blog Jekyll Theme](https://github.com/BlackrockDigital/startbootstrap-clean-blog-jekyll) which are the the two upstream projects CleanWhite Hugo theme is based on.

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -146,3 +146,15 @@ params = ["categories", "tags"]
   [markup.goldmark]
     [markup.goldmark.renderer]
       unsafe = true
+    [markup.goldmark.extensions]
+      [markup.goldmark.extensions.passthrough]
+        enable = true
+        [markup.goldmark.extensions.passthrough.delimiters]
+          block = [['\[', '\]'], ['$$', '$$']]
+          inline = [['\(', '\)']]
+
+[mediaTypes]
+  [mediaTypes.'font/woff']
+    suffixes = ['woff']
+  [mediaTypes.'font/woff2']
+    suffixes = ['woff2']

--- a/layouts/_markup/render-codeblock-chem.html
+++ b/layouts/_markup/render-codeblock-chem.html
@@ -1,0 +1,9 @@
+{{ $opts := dict "output" "htmlAndMathml" "displayMode" (not (eq ($.Type) "inline")) -}}
+{{ with try (transform.ToMath .Inner $opts) -}}
+  {{ with .Err -}}
+    {{ errorf "Unable to render mathematical markup to HTML using the transform.ToMath function. The KaTeX display engine threw the following error: %s: see %s." . $.Position -}}
+  {{ else -}}
+    {{ .Value -}}
+    {{ $.Page.Store.Set "hasMath" true -}}
+  {{ end -}}
+{{ end -}}

--- a/layouts/_markup/render-codeblock-math.html
+++ b/layouts/_markup/render-codeblock-math.html
@@ -1,0 +1,9 @@
+{{ $opts := dict "output" "htmlAndMathml" "displayMode" (not (eq ($.Type) "inline")) -}}
+{{ with try (transform.ToMath .Inner $opts) -}}
+  {{ with .Err -}}
+    {{ errorf "Unable to render mathematical markup to HTML using the transform.ToMath function. The KaTeX display engine threw the following error: %s: see %s." . $.Position -}}
+  {{ else -}}
+    {{ .Value -}}
+    {{ $.Page.Store.Set "hasMath" true -}}
+  {{ end -}}
+{{ end -}}

--- a/layouts/_markup/render-passthrough.html
+++ b/layouts/_markup/render-passthrough.html
@@ -1,0 +1,9 @@
+{{ $opts := dict "output" "htmlAndMathml" "displayMode" (not (eq ($.Type) "inline")) -}}
+{{ with try (transform.ToMath .Inner $opts) -}}
+  {{ with .Err -}}
+    {{ errorf "Unable to render mathematical markup to HTML using the transform.ToMath function. The KaTeX display engine threw the following error: %s: see %s." . $.Position -}}
+  {{ else -}}
+    {{ .Value -}}
+    {{ $.Page.Store.Set "hasMath" true -}}
+  {{ end -}}
+{{ end -}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -68,6 +68,13 @@
     <!-- Custom Fonts -->
     <link rel="stylesheet" href="{{ "css/font-awesome.all.min.css" | relURL }}">
 
+    <!-- KaTeX CSS  -->
+    {{ $noop := .WordCount }}
+    {{ if .Page.Store.Get "hasMath" -}}
+        {{ partial "math/katex-css.html" . -}}
+        {{ partial "math/katex-fonts.html" . -}}
+    {{ end -}}
+
     <!--  Custom CSS  -->
     {{ range .Site.Params.custom_css -}}
     <link rel="stylesheet" href="{{ . | absURL }}">

--- a/layouts/partials/math/katex-css.html
+++ b/layouts/partials/math/katex-css.html
@@ -1,0 +1,14 @@
+{{ $cssFile := cond hugo.IsProduction "katex.min.css" "katex.css" -}}
+{{ $cssUrl := printf "https://unpkg.com/katex@latest/dist/%s" $cssFile -}}
+{{ with try (resources.GetRemote $cssUrl) -}}
+  {{ with .Err -}}
+    {{ errorf "Could not retrieve KaTeX css file from CDN. Reason: %s." . -}}
+  {{ else with .Value -}}
+    {{ with resources.Copy (printf "css/%s" $cssFile) . -}}
+      {{ $cssHash := . | fingerprint "sha512" -}}
+<link rel="stylesheet" href="{{- .RelPermalink -}}" integrity="{{- $cssHash.Data.Integrity -}}" crossorigin="anonymous">
+    {{ end -}}
+  {{ else -}}
+    {{ errorf "Could not retrieve css file %q from CDN. Reason: invalid KaTeX version %q." $cssUrl "latest" -}}
+  {{ end -}}
+{{ end -}}

--- a/layouts/partials/math/katex-fonts.html
+++ b/layouts/partials/math/katex-fonts.html
@@ -1,0 +1,30 @@
+{{ $fontFiles := slice -}}
+{{ $data := dict -}}
+{{ $url := ( printf "https://unpkg.com/katex@latest/dist/fonts?meta" ) -}}
+{{ with try (resources.GetRemote $url) -}}
+  {{ with .Err -}}
+    {{ errorf "%s" . -}}
+  {{ else with ( .Value | unmarshal ) -}}
+      {{ range .files -}}
+        {{ $fontFiles = $fontFiles | append .path -}}
+      {{ end -}}
+  {{ else -}}
+    {{ errorf "Unable to get fonts meta data %q from CDN. Reason: invalid KaTeX version %q." $url "latest" -}}
+  {{ end -}}
+{{ end -}}
+
+{{ range $fontFile := $fontFiles -}}
+  {{ $fontUrl := (printf "https://unpkg.com/katex@latest%s" $fontFile) -}}
+  {{ with try (resources.GetRemote $fontUrl) -}}
+    {{ with .Err -}}
+      {{ errorf "Could not retrieve KaTeX font file from CDN. Reason: %s." . -}}
+    {{ else with .Value -}}
+      {{ with resources.Copy (printf "css/fonts/%s" (replace $fontFile "/dist/fonts/" "")) . -}}
+        {{ .Publish -}}
+      {{ end -}}
+    {{ else -}}
+      {{ errorf "Could not retrieve font file %q from CDN. Reason: invalid KaTeX version %q." $fontUrl "latest" -}}
+      {{ break -}}
+    {{ end -}}
+  {{ end -}}
+{{ end -}}


### PR DESCRIPTION
This PR follows up on #170. It brings server side rendering of math equations via hugo's built-in KaTeX rendering engine.

**Advantages:**
- typesetting of formulae using LaTeX standard syntax, no escaping of delimiters needed
- no need to activate math mode in frontmatter
- internal rendering engine supports rendering of chemical equations out of the box (as of hugo version 0.144.0)
- no need to include KaTeX dependencies
- - server side rendering (instead of client side rendering)
- no JS needed for math content