### PR TITLE
Fix deprecation warning emitted form hugo 0.156.0

### DIFF
--- a/layouts/list.algolia.json
+++ b/layouts/list.algolia.json
@@ -1,35 +1,37 @@
 {{/* Generates a valid Algolia search index */}}
 {{- $.Scratch.Add "index" slice -}}
 {{- $section := $.Site.GetPage "section" .Section }}
-{{- range .Site.AllPages -}}
-  {{- if and (and (.IsDescendant $section) (and (not .Draft) (not .Params.private))) $section.IsHome -}}
-    {{- if and .File (not .Params.search_exclude) -}}   {{/* ⟵ exclude by flag */}}
-      {{- $.Scratch.Add "index" (dict
-        "objectID" .File.UniqueID
-        "date" .Date.UTC.Unix
-        "dir" .File.Dir
-        "expirydate" .ExpiryDate.UTC.Unix
-        "fuzzywordcount" .FuzzyWordCount
-        "keywords" .Keywords
-        "kind" .Kind
-        "lang" .Lang
-        "lastmod" .Lastmod.UTC.Unix
-        "permalink" .Permalink
-        "publishdate" .PublishDate
-        "readingtime" .ReadingTime
-        "relpermalink" .RelPermalink
-        "html" .Params.Description
-        "title" .Title
-        "type" .Type
-        "url" .RelPermalink
-        "weight" .Weight
-        "wordcount" .WordCount
-        "section" .Section
-        "tags" .Params.Tags
-        "categories" .Params.Categories
-        "author" .Params.authors
-        "content" (truncate 1000 .Plain)
-      ) -}}
+{{ range hugo.Sites }}
+  {{- range .Pages -}}
+    {{- if and (and (.IsDescendant $section) (and (not .Draft) (not .Params.private))) $section.IsHome -}}
+      {{- if and .File (not .Params.search_exclude) -}}   {{/* ⟵ exclude by flag */}}
+        {{- $.Scratch.Add "index" (dict
+          "objectID" .File.UniqueID
+          "date" .Date.UTC.Unix
+          "dir" .File.Dir
+          "expirydate" .ExpiryDate.UTC.Unix
+          "fuzzywordcount" .FuzzyWordCount
+          "keywords" .Keywords
+          "kind" .Kind
+          "lang" .Lang
+          "lastmod" .Lastmod.UTC.Unix
+          "permalink" .Permalink
+          "publishdate" .PublishDate
+          "readingtime" .ReadingTime
+          "relpermalink" .RelPermalink
+          "html" .Params.Description
+          "title" .Title
+          "type" .Type
+          "url" .RelPermalink
+          "weight" .Weight
+          "wordcount" .WordCount
+          "section" .Section
+          "tags" .Params.Tags
+          "categories" .Params.Categories
+          "author" .Params.authors
+          "content" (truncate 1000 .Plain)
+        ) -}}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
When running example site with latest released hugo version 0.156.0, a deprecation warning is shown:

```
INFO  deprecated: .Site.AllPages was deprecated in Hugo v0.156.0 and will be removed in a future release.
See https://discourse.gohugo.io/t/56732.
```
This PR fixes this issue.