### PR TITLE
Update hugo-theme-cleanwhite.css for enabling dark mode tables

### DIFF
--- a/static/css/hugo-theme-cleanwhite.css
+++ b/static/css/hugo-theme-cleanwhite.css
@@ -122,7 +122,8 @@ img.shadow{
     }
 }
 .table th,.table td{
-    border:1px solid var(--color-border)!important
+    border:1px solid var(--color-border)!important;
+    background-color: var(--color-bg)
 }
 hr.small{
     max-width:100px;


### PR DESCRIPTION
The tables in new dark mode where not realy adapted to dark mode. With this line you have a great readable result